### PR TITLE
fix: improve Git repository detection to support worktree and submodule

### DIFF
--- a/setup-project.sh
+++ b/setup-project.sh
@@ -59,8 +59,8 @@ create_project() {
         fi
     fi
     
-    # 元のリポジトリがGitリポジトリかチェック
-    if [[ ! -d "$source_repo_path/.git" ]]; then
+    # 元のリポジトリがGitリポジトリかチェック（.gitディレクトリまたは.gitファイル）
+    if [[ ! -d "$source_repo_path/.git" && ! -f "$source_repo_path/.git" ]]; then
         print_error "指定されたパスはGitリポジトリではありません: $source_repo_path"
         cleanup_script 1
     fi


### PR DESCRIPTION
## 概要

setup-project.shのGitリポジトリ検出ロジックを改善し、Git worktreeとsubmoduleに対応しました。

## 変更内容

### 修正箇所
- `setup-project.sh` の59-65行目: Gitリポジトリ検証処理

### 変更詳細
**変更前**:
```bash
# 元のリポジトリがGitリポジトリかチェック
if [[ ! -d "$source_repo_path/.git" ]]; then
```

**変更後**:
```bash
# 元のリポジトリがGitリポジトリかチェック（.gitディレクトリまたは.gitファイル）
if [[ ! -d "$source_repo_path/.git" && ! -f "$source_repo_path/.git" ]]; then
```

## 改善点

この変更により、以下のGit使用パターンに対応できるようになりました：

1. **通常のGitリポジトリ**: `.git`ディレクトリが存在する場合
2. **Git worktree**: `.git`ファイルが存在する場合（worktreeでは`.git`がファイルとして存在し、実際のGitディレクトリへのパスが記載されている）
3. **Git submodule**: サブモジュールでも`.git`ファイルとして存在する場合がある

## DRY原則への準拠

- **単一責任の原則**: Gitリポジトリ検出の責務をより正確に実装
- **汎用性の向上**: 現代的なGit使用パターンに対応することで、より再利用可能なコードに改善

## テスト

- [x] 通常のGitリポジトリでの動作確認
- [x] コード変更の妥当性確認
- [x] 既存機能への影響なし

## 関連Issue

なし（保守性向上のための改善）